### PR TITLE
(WIP) DE631: do not allow /30, /31, /32

### DIFF
--- a/neutronclient/v2_0/client.py
+++ b/neutronclient/v2_0/client.py
@@ -20,6 +20,7 @@ import logging
 import time
 import urllib
 import urlparse
+import netaddr
 
 from neutronclient import client
 from neutronclient.common import _
@@ -367,11 +368,44 @@ class Client(object):
     @APIParamsCall
     def create_subnet(self, body=None):
         """Creates a new subnet."""
+        try:
+            ip = netaddr.IPNetwork(body['subnet']['cidr'])
+            if ip.size < 8:
+                msg = "Error: %s has size %d" % (
+                      body['subnet']['cidr'], ip.size)
+                raise exceptions.Error(msg)
+            if 'gateway_ip' in body['subnet']:
+                gw = netaddr.IPAddress(body['subnet']['gateway_ip'])
+                if gw not in ip:
+                    msg = "Error: %s is not in network %s" % (
+                              body['subnet']['gateway_ip'],
+                              body['subnet']['cidr'])
+                    raise exceptions.Error(msg)
+        except:
+            raise
         return self.post(self.subnets_path, body=body)
 
     @APIParamsCall
     def update_subnet(self, subnet, body=None):
         """Updates a subnet."""
+        try:
+            if 'cidr' in body['subnet']:
+                ip = netaddr.IPNetwork(body['subnet']['cidr'])
+            else:
+                entry = self.get(self.subnet_path % (subnet))
+                ip = netaddr.IPNetwork(entry['subnet']['cidr'])
+            if ip.size < 8:
+                msg = "Error: %s has size %d" % (
+                          body['subnet']['cidr'], ip.size)
+                raise exceptions.Error(msg)
+            if 'gateway_ip' in body['subnet']:
+                gw = netaddr.IPAddress(body['subnet']['gateway_ip'])
+                if gw not in ip:
+                    msg = "Error: %s is not in network %s" % (
+                              body['subnet']['gateway_ip'], ip)
+                    raise exceptions.Error(msg)
+        except:
+            raise
         return self.put(self.subnet_path % (subnet), body=body)
 
     @APIParamsCall

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ argparse
 cliff>=1.4.3
 httplib2
 iso8601>=0.1.4
+netaddr
 simplejson>=2.0.9
 six
 Babel>=0.9.6


### PR DESCRIPTION
WORK IN PROGRESS/DO NOT MERGE YET/DOESN'T PASS UNIT TESTS

This patch causes and exception to be thrown if the user attempts
to create or modify a subnet to have a /30, /31, or /32 mask.
This patch is a squashing and minor tidying-up of the changes
to python-neutronclient from two separate commits to the old
puppet-coe-service-patch module:

dff604420c48dfe47467cdd1b48687443fb7b32a
56bb890def8abed63f77bad42da39ae78e1229f4

The commit messages from those follow below.  Note that these patches
pertain partly to upstream bug #1341040, for which the community merged
a different fix that only logs a warning rather than throwing an
exception: https://review.openstack.org/#/c/106678
However the upstream approach was deemed insufficient and is
therefore not implemented here.

---

commit dff604420c48dfe47467cdd1b48687443fb7b32a
Author: Pauline Yeung yeungp@cisco.com
Date:   Wed Jul 23 17:49:45 2014 -0700

```
DE631 do not allow /30, as creating the first VM may require network with
at least 5 IP addresses.

Change-Id: I1bb48a512adeb509073b8b1c61520db8ea555768
```

---

commit 56bb890def8abed63f77bad42da39ae78e1229f4
Author: Pauline Yeung yeungp@cisco.com
Date:   Thu Jun 26 11:45:35 2014 -0700

```
DE494: verify subnet configuration has valid CIDR and gateway.

Change-Id: I5242326caaf2ccf79a8843596a22094d9a3ba623
```

---

Partial-bug: #1341040
Partial-rally-bug: rally-bug DE631
Partial-rally-bug: rally-bug DE494
Implements: rally-user-story US4145
Implements: rally-task TA3473
Not-in-upstream: true
