### PR TITLE
DE494/631: do not allow /30, /31, /32, bad gateway

### DIFF
--- a/neutronclient/tests/unit/test_cli20_subnet.py
+++ b/neutronclient/tests/unit/test_cli20_subnet.py
@@ -20,6 +20,10 @@ import sys
 from neutronclient.neutron.v2_0 import subnet
 from neutronclient.tests.unit import test_cli20
 
+cidrvalue = '1.1.1.0/24'
+gatewayvalue = '1.1.1.1'
+prefixvalue = '1.1.1.0/24'
+
 
 class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
     def setUp(self):
@@ -32,8 +36,8 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'cidrvalue'
-        gateway = 'gatewayvalue'
+        cidr = cidrvalue
+        gateway = gatewayvalue
         args = ['--gateway', gateway, netid, cidr]
         position_names = ['ip_version', 'network_id', 'cidr', 'gateway_ip']
         position_values = [4, netid, cidr, gateway]
@@ -47,7 +51,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'cidrvalue'
+        cidr = cidrvalue
         args = ['--no-gateway', netid, cidr]
         position_names = ['ip_version', 'network_id', 'cidr', 'gateway_ip']
         position_values = [4, netid, cidr, None]
@@ -61,8 +65,8 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'cidrvalue'
-        gateway = 'gatewayvalue'
+        cidr = cidrvalue
+        gateway = gatewayvalue
         args = ['--gateway', gateway, '--no-gateway', netid, cidr]
         position_names = ['ip_version', 'network_id', 'cidr', 'gateway_ip']
         position_values = [4, netid, cidr, None]
@@ -80,7 +84,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid', netid, cidr]
         position_names = ['ip_version', 'network_id', 'cidr']
         position_values = [4, netid, cidr]
@@ -95,7 +99,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = [netid, cidr, '--tags', 'a', 'b']
         position_names = ['ip_version', 'network_id', 'cidr']
         position_values = [4, netid, cidr]
@@ -112,7 +116,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--allocation_pool', 'start=1.1.1.10,end=1.1.1.20',
                 netid, cidr]
@@ -134,7 +138,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--allocation_pool', 'start=1.1.1.10,end=1.1.1.20',
                 '--allocation_pool', 'start=1.1.1.30,end=1.1.1.40',
@@ -158,7 +162,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--host-route', 'destination=172.16.1.0/24,nexthop=1.1.1.20',
                 netid, cidr]
@@ -181,7 +185,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--host-route', 'destination=172.16.1.0/24,nexthop=1.1.1.20',
                 '--host-route', 'destination=172.17.7.0/24,nexthop=1.1.1.40',
@@ -205,7 +209,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--dns-nameserver', '1.1.1.20',
                 '--dns-nameserver', '1.1.1.40',
@@ -225,7 +229,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--disable-dhcp',
                 netid, cidr]
@@ -242,7 +246,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--allocation-pool', 'start=1.1.1.10,end=1.1.1.20',
                 netid, cidr,
@@ -263,7 +267,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 netid, cidr,
                 '--allocation-pools', 'list=true', 'type=dict',
@@ -282,7 +286,7 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         name = 'myname'
         myid = 'myid'
         netid = 'netid'
-        cidr = 'prefixvalue'
+        cidr = prefixvalue
         args = ['--tenant_id', 'tenantid',
                 '--allocation-pool', 'start=1.1.1.10,end=1.1.1.20',
                 netid, cidr,
@@ -355,8 +359,11 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         cmd = subnet.UpdateSubnet(test_cli20.MyApp(sys.stdout), None)
         self._test_update_resource(resource, cmd, 'myid',
                                    ['myid', '--name', 'myname',
+                                    '--cidr', prefixvalue,
                                     '--tags', 'a', 'b'],
-                                   {'name': 'myname', 'tags': ['a', 'b'], }
+                                   {'name': 'myname',
+                                    'cidr': prefixvalue,
+                                    'tags': ['a', 'b'], }
                                    )
 
     def test_update_subnet_known_option_before_id(self):
@@ -366,8 +373,9 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         cmd = subnet.UpdateSubnet(test_cli20.MyApp(sys.stdout), None)
         self._test_update_resource(resource, cmd, 'myid',
                                    ['--request-format', 'json',
-                                    'myid', '--name', 'myname'],
-                                   {'name': 'myname', }
+                                    'myid', '--name', 'myname',
+                                    '--cidr', prefixvalue],
+                                   {'name': 'myname', 'cidr': prefixvalue, }
                                    )
 
     def test_update_subnet_known_option_after_id(self):
@@ -377,8 +385,9 @@ class CLITestV20SubnetJSON(test_cli20.CLITestV20Base):
         cmd = subnet.UpdateSubnet(test_cli20.MyApp(sys.stdout), None)
         self._test_update_resource(resource, cmd, 'myid',
                                    ['myid', '--name', 'myname',
+                                    '--cidr', prefixvalue,
                                     '--request-format', 'json'],
-                                   {'name': 'myname', }
+                                   {'name': 'myname', 'cidr': prefixvalue, }
                                    )
 
     def test_show_subnet(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ argparse
 cliff>=1.4.3
 httplib2
 iso8601>=0.1.4
+netaddr
 simplejson>=2.0.9
 six
 Babel>=0.9.6


### PR DESCRIPTION
This patch causes and exception to be thrown if the user attempts
to create or modify a subnet to have a /30, /31, or /32 mask.
This patch is a squashing and minor tidying-up of the changes
to python-neutronclient from two separate commits to the old
puppet-coe-service-patch module:

dff604420c48dfe47467cdd1b48687443fb7b32a
56bb890def8abed63f77bad42da39ae78e1229f4

In additon, this patch fixes the subnet unit tests, which require valid cidr.

The commit messages from those follow below. Note that these patches
pertain partly to upstream bug #1341040, for which the community merged
a different fix that only logs a warning rather than throwing an
exception: https://review.openstack.org/#/c/106678
However the upstream approach was deemed insufficient and is
therefore not implemented here.

commit dff604420c48dfe47467cdd1b48687443fb7b32a
Author: Pauline Yeung yeungp@cisco.com
Date: Wed Jul 23 17:49:45 2014 -0700

DE631 do not allow /30, as creating the first VM may require network with
at least 5 IP addresses.

Change-Id: I1bb48a512adeb509073b8b1c61520db8ea555768

commit 56bb890def8abed63f77bad42da39ae78e1229f4
Author: Pauline Yeung yeungp@cisco.com
Date: Thu Jun 26 11:45:35 2014 -0700

DE494: verify subnet configuration has valid CIDR and gateway.

Change-Id: I5242326caaf2ccf79a8843596a22094d9a3ba623

Partial-bug: #1341040
Partial-rally-bug: rally-bug DE631
Partial-rally-bug: rally-bug DE494
Implements: rally-user-story US4145
Implements: rally-user-story US4456
Implements: rally-task TA3473
Implements: rally-task TA4049
Not-in-upstream: true
