### PR TITLE
Fixed get_auth_info() for pre-authenticated clients

### DIFF
--- a/neutronclient/client.py
+++ b/neutronclient/client.py
@@ -111,6 +111,8 @@ class HTTPClient(httplib2.Http):
         self.endpoint_type = endpoint_type
         self.region_name = region_name
         self.auth_token = token
+        self.auth_tenant_id = None
+        self.auth_user_id = None
         self.content_type = 'application/json'
         self.endpoint_url = endpoint_url
         self.auth_strategy = auth_strategy

--- a/neutronclient/tests/unit/test_auth.py
+++ b/neutronclient/tests/unit/test_auth.py
@@ -85,6 +85,22 @@ class CLITestAuthKeystone(testtools.TestCase):
         self.addCleanup(self.mox.VerifyAll)
         self.addCleanup(self.mox.UnsetStubs)
 
+    def test_reused_token_get_auth_info(self):
+        """Test that Client.get_auth_info() works even if client was
+           instantiated with predefined token.
+        """
+        client_ = client.HTTPClient(username=USERNAME,
+                                    tenant_name=TENANT_NAME,
+                                    token=TOKEN,
+                                    password=PASSWORD,
+                                    auth_url=AUTH_URL,
+                                    region_name=REGION)
+        expected = {'auth_token': TOKEN,
+                    'auth_tenant_id': None,
+                    'auth_user_id': None,
+                    'endpoint_url': self.client.endpoint_url}
+        self.assertEqual(client_.get_auth_info(), expected)
+
     def test_get_token(self):
         self.mox.StubOutWithMock(self.client, "request")
 


### PR DESCRIPTION
When a client is instantiated with pre-defined authorization token,
no authentication is done, so no auth_[tenant|user]_id keys are set
for HTTPClient. As a result, Client.get_auth_info() fails with KeyError.

Fixed the issue by setting those keys on HTTPClient initialization.

Closes-Bug: 1277120
Closes-rally-bug: DE726
Implements: rally-task TA4473
Upstream-Review: https://review.openstack.org/#/c/71551
Not-in-upstream: false
