### PR TITLE
Skip None id when getting security_group_ids

### DIFF
--- a/neutronclient/neutron/v2_0/securitygroup.py
+++ b/neutronclient/neutron/v2_0/securitygroup.py
@@ -140,7 +140,8 @@ class ListSecurityGroupRule(neutronV20.ListCommand):
         sec_group_ids = set()
         for rule in data:
             for key in self.replace_rules:
-                sec_group_ids.add(rule[key])
+                if rule.get(key):
+                    sec_group_ids.add(rule[key])
         search_opts.update({"id": sec_group_ids})
         secgroups = neutron_client.list_security_groups(**search_opts)
         secgroups = secgroups.get('security_groups', [])


### PR DESCRIPTION
When getting security_group_ids in securitygroup.py, a None id is
included into the list due to the remote group id is Null when the
security group rule direction is egress.
And this causes the calculation of the number of chunk_size is
1 more than the number it should be.
Then the request page size excess the MAX request page size
Then the RequestURITooLong exception happens again, and finally
the commend fails.

Closes-Bug: 1271462
Closes-rally-bug: DE1165
